### PR TITLE
Allow gravity to be set on resize_to_fill

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ Thumbnailing:
 
   # Extent
   open("input.jpg") |> extent("500x500") |> save
+  
+  # Gravity
+  open("input.jpg") |> gravity("Center") |> save
+  
 ```
 
 Converting:

--- a/lib/mogrify.ex
+++ b/lib/mogrify.ex
@@ -106,6 +106,13 @@ defmodule Mogrify do
   end
 
   @doc """
+  Sets the gravity of the image
+  """
+  def gravity(image, params) do
+    %{image | operations: image.operations ++ [gravity: params]}
+  end
+
+  @doc """
   Resize the image to fit within the specified dimensions while retaining
   the original aspect ratio. Will only resize the image if it is larger than the
   specified dimensions. The resulting image may be shorter or narrower than specified


### PR DESCRIPTION
When using resize_to_fill this allows the ability to set the gravity for the crop