### PR TITLE
Allow to create images as well as changing them

### DIFF
--- a/lib/mogrify.ex
+++ b/lib/mogrify.ex
@@ -69,13 +69,11 @@ defmodule Mogrify do
   end
 
   defp arguments(image) do
-    Enum.flat_map(image.operations, fn {option,params} ->
-      case option do
-        :image_operator -> [params]
-        _ -> ["-#{option}", params]
-      end
-    end)
+    Enum.flat_map(image.operations, &normalize_arguments/1)
   end
+
+  defp normalize_arguments({:image_operator, params}), do: [params]
+  defp normalize_arguments({option, params}), do: ["-#{option}", params]
 
   @doc """
   Makes a copy of original image

--- a/lib/mogrify.ex
+++ b/lib/mogrify.ex
@@ -25,6 +25,17 @@ defmodule Mogrify do
     image_after_command(image, output_path)
   end
 
+  @doc """
+  Creates or saves image
+
+  Uses the `convert` command, which accepts both existing images, or image
+  operators. If you have an existing image, prefer save/2.
+
+  ## Options
+
+  * `:path` - The output path of the image. Defaults to a temporary file.
+  * `:in_place` - Overwrite the original image, ignoring `:path` option. Default false.
+  """
   def create(image, opts \\ []) do
     output_path = output_path_for(image, opts)
     System.cmd("convert", arguments_for_creating(image, output_path), stderr_to_stdout: true)
@@ -53,7 +64,7 @@ defmodule Mogrify do
   end
 
   defp arguments_for_creating(image, path) do
-    base_arguments = ~w(#{path}/#{String.replace(image.path, " ", "\\ ")})
+    base_arguments = ~w(#{Path.dirname(path)}/#{String.replace(Path.basename(image.path), " ", "\\ ")})
     arguments(image) ++ base_arguments
   end
 

--- a/test/mogrify_test.exs
+++ b/test/mogrify_test.exs
@@ -64,6 +64,16 @@ defmodule MogrifyTest do
     File.rm!(path)
   end
 
+  test ".create" do
+    path = Path.join(System.tmp_dir, "1.jpg")
+    image = %Image{path: path} |> canvas("white") |> create(path: path)
+
+    assert File.exists?(path)
+    assert %Image{path: path} = image
+
+    File.rm!(path)
+  end
+
   test ".copy" do
     image = open(@fixture) |> copy
     tmp_dir = System.tmp_dir |> Regex.escape


### PR DESCRIPTION
Why:

* There are situations when it is useful to be able to create images,
  which is supported by imagemagick. As far as I could tell, it is only
  supported by the `convert` command, not `mogrify`.

This change addresses the need by:

* Separating the concepts of saving and creating, being that saving will
  use mogrify and requires an actual image file to be present beforehand
  whereas creating allows you to create a virtual canvas and then save it
  to the file.
* Because of this separation, the name of the path for creating won't
  work with the `-write` flag.
* The imagemagick syntax for creating a canvas is part of what is called
  image operators, and is something like `xc:white`, which means the
  assumption that all argument have a name prefixed with `-` and a value
  does not hold true. I think image operators the only options that do not
  follow that syntax, so I added a special case for it.

The name of the project (Mogrify) suggest it is a wrapper only to that
command, but the description seems to be more broad, as it says it's a
wrapper for imagemagick. Because of that, I am unsure if this is
something that is interesting and/or fits this project, but I wanted to
have this discussion before thinking of forking it.