### PR TITLE
Fix normalize_arguments to not split space separated params except 'annotate'

### DIFF
--- a/lib/mogrify.ex
+++ b/lib/mogrify.ex
@@ -65,11 +65,15 @@ defmodule Mogrify do
 
   defp arguments_for_creating(image, path) do
     base_arguments = ~w(#{Path.dirname(path)}/#{String.replace(Path.basename(image.path), " ", "\\ ")})
-    arguments(image) ++ base_arguments
+    a = arguments(image) ++ base_arguments
+    IO.inspect a
+    a
   end
 
   defp arguments(image) do
-    Enum.flat_map(image.operations, &normalize_arguments/1)
+    a = Enum.flat_map(image.operations, &normalize_arguments/1)
+    IO.inspect a
+    a
   end
 
   defp normalize_arguments({:image_operator, params}), do: ~w(#{params})

--- a/lib/mogrify.ex
+++ b/lib/mogrify.ex
@@ -65,15 +65,11 @@ defmodule Mogrify do
 
   defp arguments_for_creating(image, path) do
     base_arguments = ~w(#{Path.dirname(path)}/#{String.replace(Path.basename(image.path), " ", "\\ ")})
-    a = arguments(image) ++ base_arguments
-    IO.inspect a
-    a
+    arguments(image) ++ base_arguments
   end
 
   defp arguments(image) do
-    a = Enum.flat_map(image.operations, &normalize_arguments/1)
-    IO.inspect a
-    a
+    Enum.flat_map(image.operations, &normalize_arguments/1)
   end
 
   defp normalize_arguments({:image_operator, params}), do: ~w(#{params})

--- a/lib/mogrify.ex
+++ b/lib/mogrify.ex
@@ -77,7 +77,7 @@ defmodule Mogrify do
   end
 
   defp normalize_arguments({:image_operator, params}), do: ~w(#{params})
-  defp normalize_arguments({"annotate", params}), do: ~w(-annotate, #{params})
+  defp normalize_arguments({"annotate", params}), do: ~w(-annotate #{params})
   defp normalize_arguments({"+" <> option, params}), do: ["+" <> option, params]
   defp normalize_arguments({"-" <> option, params}), do: ["-" <> option, params]
   defp normalize_arguments({option, params}), do: ["-" <> option, params]

--- a/lib/mogrify.ex
+++ b/lib/mogrify.ex
@@ -77,7 +77,7 @@ defmodule Mogrify do
   end
 
   defp normalize_arguments({:image_operator, params}), do: ~w(#{params})
-  defp normalize_arguments({"annotate", params}), do: ~w("-annotate", #{params})
+  defp normalize_arguments({"annotate", params}), do: ~w(-annotate, #{params})
   defp normalize_arguments({"+" <> option, params}), do: ["+" <> option, params]
   defp normalize_arguments({"-" <> option, params}), do: ["-" <> option, params]
   defp normalize_arguments({option, params}), do: ["-" <> option, params]

--- a/lib/mogrify.ex
+++ b/lib/mogrify.ex
@@ -73,9 +73,9 @@ defmodule Mogrify do
   end
 
   defp normalize_arguments({:image_operator, params}), do: ~w(#{params})
-  defp normalize_arguments({"+" <> option, params}), do: ~w(+#{option} #{params})
-  defp normalize_arguments({"-" <> option, params}), do: ~w(-#{option} #{params})
-  defp normalize_arguments({option, params}), do: ~w(-#{option} #{params})
+  defp normalize_arguments({"+" <> option, params}), do: ["+" <> option, params]
+  defp normalize_arguments({"-" <> option, params}), do: ["-" <> option, params]
+  defp normalize_arguments({option, params}), do: ["-" <> option, params]
 
   @doc """
   Makes a copy of original image

--- a/lib/mogrify.ex
+++ b/lib/mogrify.ex
@@ -74,9 +74,9 @@ defmodule Mogrify do
 
   defp normalize_arguments({:image_operator, params}), do: ~w(#{params})
   defp normalize_arguments({"annotate", params}), do: ~w(-annotate #{params})
-  defp normalize_arguments({"+" <> option, params}), do: ["+" <> option, params]
-  defp normalize_arguments({"-" <> option, params}), do: ["-" <> option, params]
-  defp normalize_arguments({option, params}), do: ["-" <> option, params]
+  defp normalize_arguments({"+" <> option, params}), do: ["+" <> to_string(option), to_string(params)]
+  defp normalize_arguments({"-" <> option, params}), do: ["-" <> to_string(option), to_string(params)]
+  defp normalize_arguments({option, params}), do: ["-" <> to_string(option), to_string(params)]
 
   @doc """
   Makes a copy of original image

--- a/lib/mogrify.ex
+++ b/lib/mogrify.ex
@@ -77,6 +77,7 @@ defmodule Mogrify do
   end
 
   defp normalize_arguments({:image_operator, params}), do: ~w(#{params})
+  defp normalize_arguments({"annotate", params}), do: ~w("-annotate", #{params})
   defp normalize_arguments({"+" <> option, params}), do: ["+" <> option, params]
   defp normalize_arguments({"-" <> option, params}), do: ["-" <> option, params]
   defp normalize_arguments({option, params}), do: ["-" <> option, params]


### PR DESCRIPTION
fix normalize_arguments to handle 'annotate' and 'draw' commands separately.