### PR TITLE
fix: filter out empty arguments to avoid read() timeouts

### DIFF
--- a/lib/mogrify.ex
+++ b/lib/mogrify.ex
@@ -70,6 +70,7 @@ defmodule Mogrify do
 
   defp arguments(image) do
     Enum.flat_map(image.operations, &normalize_arguments/1)
+    |> Enum.filter(fn(x) -> x != "" end)
   end
 
   defp normalize_arguments({:image_operator, params}), do: ~w(#{params})


### PR DESCRIPTION
I could not use commands with empty arguments (e.g. `auto_orient`) because it lead to mogrify processes infinitely waiting in `read()` calls. After some investigation I identified the empty arguments generated by 'arguments/1` function. Filtering them out helped.