### PR TITLE
Add pango as a parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,21 @@ Getting info:
   IO.inspect(image) # => %Image{path: "input.jpg", ext: ".jpg", format: "jpeg", height: 292, width: 300}
 ```
 
+Using custom commands to create an image with markup:
+
+```elixir
+  import Mogrify
+
+  %Mogrify.Image{path: "test.png", ext: "png"}
+  |> custom("size", "280x280")
+  |> custom("background", "#000000")
+  |> custom("gravity", "center")
+  |> custom("fill", "white")
+  |> custom("font", "DejaVu-Sans-Mono-Bold")
+  |> custom("pango", ~S(<span foreground="yellow">hello markup world</span>))
+  |> create(path: ".")
+```
+
 Creating new images: See [mogrify_draw](https://github.com/zamith/mogrify_draw) for an example of generating a new image from scratch.
 
 

--- a/lib/mogrify.ex
+++ b/lib/mogrify.ex
@@ -126,6 +126,7 @@ defmodule Mogrify do
   defp normalize_arguments({:image_operator, params}), do: ~w(#{params})
   defp normalize_arguments({"annotate", params}),      do: ~w(-annotate #{params})
   defp normalize_arguments({"histogram:" <> option, nil}),      do: ["histogram:#{option}"]
+  defp normalize_arguments({"pango", params}),      do: ["pango:#{params}"]
   defp normalize_arguments({"+" <> option, nil}),      do: ["+#{option}"]
   defp normalize_arguments({"-" <> option, nil}),      do: ["-#{option}"]
   defp normalize_arguments({option, nil}),             do: ["-#{option}"]

--- a/test/mogrify_test.exs
+++ b/test/mogrify_test.exs
@@ -123,6 +123,43 @@ defmodule MogrifyTest do
     File.rm_rf!(@temp_test_directory)
   end
 
+  test "pango success" do
+    path = Path.join(System.tmp_dir, "1.jpg")
+    image = %Image{path: path} |> custom("pango", ~S(<span foreground="yellow">hello test</span>)) |> create(path: path)
+
+    assert File.exists?(path) == true
+    assert %Image{path: ^path} = image
+
+    File.rm!(path)
+  end
+
+  test "pango by using single quotes" do
+    path = Path.join(System.tmp_dir, "1.jpg")
+    image = %Image{path: path} |> custom("pango", ~S('<span foreground="yellow">hello test</span>')) |> create(path: path)
+
+    assert File.exists?(path) == true
+    assert %Image{path: ^path} = image
+
+    File.rm!(path)
+  end
+
+  test "pango by wrapping in <markup /> tags" do
+    path = Path.join(System.tmp_dir, "1.jpg")
+    image = %Image{path: path} |> custom("pango", ~S(<markup><span foreground="yellow">hello test</span></markup>')) |> create(path: path)
+
+    assert File.exists?(path) == true
+    assert %Image{path: ^path} = image
+
+    File.rm!(path)
+  end
+
+  test "pango with invalid markup" do
+    path = Path.join(System.tmp_dir, "1.jpg")
+    %Image{path: path} |> custom("pango", ~S(<span foreground="yellow">hello test)) |> create(path: path)
+
+    assert File.exists?(path) == false
+  end
+
   test ".copy" do
     image = open(@fixture) |> copy
     tmp_dir = System.tmp_dir |> Regex.escape

--- a/test/mogrify_test.exs
+++ b/test/mogrify_test.exs
@@ -39,8 +39,8 @@ defmodule MogrifyTest do
 
     image = open(@fixture) |> save(path: path)
 
-    assert File.regular?(path)
-    assert %Image{path: path} = image
+    assert File.regular?(path) == true
+    assert %Image{path: ^path} = image
     File.rm!(path)
   end
 
@@ -49,7 +49,7 @@ defmodule MogrifyTest do
 
     image = open(@fixture) |> save(path: @temp_image_with_space)
 
-    assert File.regular?(@temp_image_with_space)
+    assert File.regular?(@temp_image_with_space) == true
     assert %Image{path: @temp_image_with_space} = image
 
     File.rm_rf!(@temp_test_directory)
@@ -62,7 +62,7 @@ defmodule MogrifyTest do
 
     # test begins
     image = open(path) |> resize("600x600") |> save(in_place: true) |> verbose
-    assert %Image{path: path, height: 584, width: 600} = image
+    assert %Image{path: ^path, height: 584, width: 600} = image
 
     File.rm!(path)
   end
@@ -86,7 +86,7 @@ defmodule MogrifyTest do
 
     # test begins
     image = open(path) |> resize("600x600") |> save(in_place: true, path: "#{path}-ignore") |> verbose
-    assert %Image{path: path, height: 584, width: 600} = image
+    assert %Image{path: ^path, height: 584, width: 600} = image
 
     File.rm!(path)
   end
@@ -107,8 +107,8 @@ defmodule MogrifyTest do
     path = Path.join(System.tmp_dir, "1.jpg")
     image = %Image{path: path} |> canvas("white") |> create(path: path)
 
-    assert File.exists?(path)
-    assert %Image{path: path} = image
+    assert File.exists?(path) == true
+    assert %Image{path: ^path} = image
 
     File.rm!(path)
   end
@@ -117,7 +117,7 @@ defmodule MogrifyTest do
     File.mkdir_p!(@temp_test_directory)
     image = %Image{path: @temp_image_with_space} |> canvas("white") |> create(path: @temp_image_with_space)
 
-    assert File.exists?(@temp_image_with_space)
+    assert File.exists?(@temp_image_with_space) == true
     assert %Image{path: @temp_image_with_space} = image
 
     File.rm_rf!(@temp_test_directory)


### PR DESCRIPTION
Hello,

This is the first try to use pango with `Mogrify.custom`

I encountered the same problem as https://github.com/route/mogrify/issues/55 in one of my projects

## TODO
- [x] Tests
- [x] Documentation
- [x] Polishing :wink: 

## Example:

```elixir
    %Mogrify.Image{path: filename, ext: "png"}
    |> custom("size", "280x280")
    |> custom("background", "#000000")
    |> custom("gravity", "center")
    |> custom("fill", "white")
    |> custom("font", "DejaVu-Sans-Mono-Bold")
    |> custom("pango", "#{text}")
    |> create(path: path)
```