### PR TITLE
Testing fails without Pango, create folder if doesn't exist

### DIFF
--- a/lib/mogrify.ex
+++ b/lib/mogrify.ex
@@ -23,6 +23,8 @@ defmodule Mogrify do
   """
   def save(image, opts \\ []) do
     output_path = output_path_for(image, opts)
+    create_folder_if_doesnt_exist!(output_path)
+
     cmd_mogrify(arguments_for_saving(image, output_path), stderr_to_stdout: true)
     image_after_command(image, output_path)
   end
@@ -77,6 +79,7 @@ defmodule Mogrify do
     args = arguments(img) ++ [image.path, "histogram:info:-"]
 
     res = cmd_convert(args, stderr_to_stdout: false)
+
     res
     |> elem(0)
     |> process_histogram_output
@@ -84,6 +87,7 @@ defmodule Mogrify do
 
   defp image_after_command(image, output_path) do
     format = Map.get(image.dirty, :format, image.format)
+
     %{
       clear_operations(image)
       | path: output_path,
@@ -375,5 +379,9 @@ defmodule Mogrify do
       {:win32, _} -> System.cmd("cmd.exe", ["/c", "magick", "convert"] ++ args, opts)
       _ -> System.cmd("convert", args, opts)
     end
+  end
+
+  defp create_folder_if_doesnt_exist!(path) do
+    path |> Path.dirname() |> File.mkdir_p!()
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -6,10 +6,11 @@ defmodule Mogrify.Mixfile do
       app: :mogrify,
       version: "0.7.2",
       elixir: ">= 1.2.0",
+      elixirc_paths: elixirc_paths(Mix.env()),
       description: description(),
       package: package(),
       deps: deps()
-     ]
+    ]
   end
 
   def application do
@@ -32,4 +33,7 @@ defmodule Mogrify.Mixfile do
       links: %{"GitHub" => "https://github.com/route/mogrify"}
     ]
   end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
 end

--- a/test/mogrify_test.exs
+++ b/test/mogrify_test.exs
@@ -113,6 +113,17 @@ defmodule MogrifyTest do
     File.rm_rf!(@temp_test_directory)
   end
 
+  test "save should create directory if it doesn't exist" do
+    path_to_delete = Path.join(System.tmp_dir(), "/folder-doesnt-exist1/")
+    path = path_to_delete <> "/folder-doesnt-exist2/folder-doesnt-exist3/1.jpg"
+
+    image = open(@fixture) |> save(path: path)
+
+    assert File.regular?(path)
+    assert %Image{path: ^path} = image
+    File.rm_rf!(path_to_delete)
+  end
+
   test ".create" do
     path = Path.join(System.tmp_dir(), "1.jpg")
     image = %Image{} |> canvas("white") |> create(path: path)

--- a/test/mogrify_test.exs
+++ b/test/mogrify_test.exs
@@ -148,6 +148,7 @@ defmodule MogrifyTest do
     File.rm_rf!(@temp_test_directory)
   end
 
+  @tag :pango
   test "pango success" do
     path = Path.join(System.tmp_dir(), "1.jpg")
 
@@ -162,6 +163,7 @@ defmodule MogrifyTest do
     File.rm!(path)
   end
 
+  @tag :pango
   test "pango by using single quotes" do
     path = Path.join(System.tmp_dir(), "1.jpg")
 
@@ -176,6 +178,7 @@ defmodule MogrifyTest do
     File.rm!(path)
   end
 
+  @tag :pango
   test "pango by wrapping in <markup /> tags" do
     path = Path.join(System.tmp_dir(), "1.jpg")
 
@@ -190,6 +193,7 @@ defmodule MogrifyTest do
     File.rm!(path)
   end
 
+  @tag :pango
   test "pango with invalid markup" do
     path = Path.join(System.tmp_dir(), "1.jpg")
 
@@ -200,6 +204,7 @@ defmodule MogrifyTest do
     assert File.exists?(path) == false
   end
 
+  @tag :pango
   test "binary output" do
     image =
       %Image{}
@@ -210,6 +215,7 @@ defmodule MogrifyTest do
     assert is_binary(image.buffer)
   end
 
+  @tag :pango
   test "binary output using into: IO.stream/2" do
     stdout =
       capture_io(fn ->
@@ -225,6 +231,7 @@ defmodule MogrifyTest do
     assert is_binary(stdout)
   end
 
+  @tag :pango
   test "binary output buffer matches file output" do
     image =
       %Image{}

--- a/test/support/mogrify_detect.ex
+++ b/test/support/mogrify_detect.ex
@@ -1,0 +1,17 @@
+defmodule Mogrify.Detect do
+  @spec has_imagemagick?() :: boolean()
+  def has_imagemagick?() do
+    "convert"
+    |> System.find_executable()
+    |> is_nil()
+    |> Kernel.!()
+  end
+
+  @spec has_pango?() :: boolean()
+  def has_pango?() do
+    {version, _} = System.cmd("convert", ["version"])
+    String.contains?(version, "pangocairo")
+  rescue
+    _ -> false
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,7 @@
-ExUnit.start()
+import Mogrify.Detect
+
+if has_imagemagick?() && has_pango?() do
+  ExUnit.start()
+else
+  ExUnit.start(exclude: [:pango])
+end


### PR DESCRIPTION
Fixing issue #67 and #72 

Regarding #72 
This was suppose to be a separate pull request, sorry I messed up my branches

Regarding #67 
I tried to detect if the user had imagemagick and pango installed in test_helper but it was getting too messy, instead I created a module inside the test/support folder

If you prefer another approach please let me know.