### PR TITLE
Allow annotations bigger than 1 word

### DIFF
--- a/lib/mogrify.ex
+++ b/lib/mogrify.ex
@@ -157,7 +157,10 @@ defmodule Mogrify do
   end
 
   defp normalize_arguments({:image_operator, params}), do: ~w(#{params})
-  defp normalize_arguments({"annotate", params}), do: ~w(-annotate #{params})
+
+  defp normalize_arguments({"annotate", params}),
+    do: ["-annotate"] ++ String.split(params, " ", parts: 2)
+
   defp normalize_arguments({"histogram:" <> option, nil}), do: ["histogram:#{option}"]
   defp normalize_arguments({"pango", params}), do: ["pango:#{params}"]
   defp normalize_arguments({"stdout", params}), do: ["#{params}"]


### PR DESCRIPTION
I was having trouble with annotations because ~w() was making each word a separate argument.  Fixes issue #79 