### PR TITLE
Fixed typo which was failing tests on Windows

### DIFF
--- a/lib/mogrify.ex
+++ b/lib/mogrify.ex
@@ -292,7 +292,7 @@ defmodule Mogrify do
   in the smaller dimension but will not be larger than the specified values.
   """
   def resize_to_limit(image, params) do
-    resize(image, "#{params}>")
+    resize(image, "#{params}")
   end
 
   @doc """


### PR DESCRIPTION
This commit fixes 6/8 failing tests running on Windows due to not being able to create an image in the temp directory which caused the image to stay in the same directory as the original image (with original image' having `~` in it's name) so next tests were failing as well.

Currently there are also 2 tests failing where comparing paths is failing. I'll try to solve this one too if I get lucky :) 
`test/mogrify_test.exs:85` and `test/mogrify_test.exs:61` - these existed even before my fix