### PR TITLE
create and save err if new image file is not successfully created

### DIFF
--- a/lib/mogrify.ex
+++ b/lib/mogrify.ex
@@ -5,7 +5,6 @@ defmodule Mogrify do
   alias Mogrify.Image
   alias Mogrify.Option
 
-
   @doc """
   Opens image source
   """
@@ -28,7 +27,7 @@ defmodule Mogrify do
     output_path = output_path_for(image, opts)
     create_folder_if_doesnt_exist!(output_path)
 
-    cmd_mogrify(arguments_for_saving(image, output_path), stderr_to_stdout: true)
+    {_, 0} = cmd_mogrify(arguments_for_saving(image, output_path), stderr_to_stdout: true)
     image_after_command(image, output_path)
   end
 
@@ -56,7 +55,7 @@ defmodule Mogrify do
       output_path = output_path_for(image, opts)
       create_folder_if_doesnt_exist!(output_path)
 
-      cmd_convert(arguments_for_creating(image, output_path), cmd_opts)
+      {_, 0} = cmd_convert(arguments_for_creating(image, output_path), cmd_opts)
       image_after_command(image, output_path)
     end
   end


### PR DESCRIPTION
## What does this do?

Deals with Issue #65 

Currently `create/2` and `save/2` fail silently if the file is not created as they don't check the result of the `System.cmd` call.

`System.cmd` returns a tuple with the result and the command exit status, so by pattern matching the result of `cmd_mogrify` and `cmd_convert` against a successful attempt (`{_, 0}`) these functions will now raise an error for unsuccessful exist statuses.

This is similar to the implementation for buffer in `create/2`.

## How to test?

Try to save a file with an illegal file type, and error should be raised.

```
iex(3)> Mogrify.open("sample.png") |> format("jpg") |> save
%Mogrify.Image{
  animated: false,
  buffer: nil,
  dirty: %{},
  ext: ".jpg",
  format: "jpg",
  frame_count: 1,
  height: nil,
  operations: [],
  path: "/var/folders/hs/6c8zskxs7891h185psnyk3wm0000gn/T/18777-sample.jpg",
  width: nil
}
iex(4)> Mogrify.open("sample.png") |> format("doggos") |> save
** (MatchError) no match of right hand side value: {"mogrify: unable to open image 'doggos:': No such file or directory @ error/blob.c/OpenBlob/3537.\nmogrify: unrecognized image format `doggos' @ error/mogrify.c/MogrifyImageCommand/5062.\n", 1}
    (mogrify 0.7.4) lib/mogrify.ex:30: Mogrify.save/2
```

## What needs to be considered ?

It may be nice to have it throw a better error, but I'd leave the shape of that open for discussion