### PR TITLE
Parse histograms with fractional colors

### DIFF
--- a/lib/mogrify.ex
+++ b/lib/mogrify.ex
@@ -119,10 +119,10 @@ defmodule Mogrify do
   defp clean_histogram_entry({"hex", v}), do: {"hex", v}
   defp clean_histogram_entry({"alpha", ""}), do: {"alpha", 255}
   defp clean_histogram_entry({k, ""}), do: {k, 0}
-  defp clean_histogram_entry({k, v}), do: {k, v |> String.to_integer()}
+  defp clean_histogram_entry({k, v}), do: {k, v |> Float.parse() |> elem(0) |> Float.round(0) |> trunc}
 
-  defp extract_histogram_data(entry) do
-    ~r/^\s+(?<count>\d+):\s+\((?<red>[\d\s]+),(?<green>[\d\s]+),(?<blue>[\d\s]+)(,(?<alpha>[\d\s]+))?\)\s+(?<hex>\#[abcdef\d]{6,8})\s+/i
+  def extract_histogram_data(entry) do
+    ~r/^\s+(?<count>\d+):\s+\((?<red>[\d(?:\.\d+)?)\s]+),(?<green>[\d(?:\.\d+)?)\s]+),(?<blue>[\d(?:\.\d+)?)\s]+)(,(?<alpha>[\d(?:\.\d+)?)\s]+))?\)\s+(?<hex>\#[abcdef\d]{6,8})\s+/i
     |> Regex.named_captures(entry)
     |> Enum.map(fn {k, v} -> {k, v |> Compat.string_trim()} end)
     |> cleanse_histogram

--- a/test/mogrify_test.exs
+++ b/test/mogrify_test.exs
@@ -498,6 +498,23 @@ defmodule MogrifyTest do
       }
     ]
 
+    assert hist ==  expected
+  end
+
+  test ".histogram with fractional rgb values" do
+    hist = open(@fixture) |> custom("-alpha", "remove")
+    |> custom("-colors", 8)
+    |> histogram
+    expected =  [
+      %{"alpha" => 255, "blue" => 34, "count" => 1976, "green" => 33, "hex" => "#202122", "red" => 32},
+      %{"alpha" => 255, "blue" => 64, "count" => 2424, "green" => 63, "hex" => "#3E3F40", "red" => 62},
+      %{"alpha" => 255, "blue" => 103, "count" => 4669, "green" => 101, "hex" => "#656567", "red" => 101},
+      %{"alpha" => 255, "blue" => 127, "count" => 1319, "green" => 128, "hex" => "#7D807F", "red" => 125},
+      %{"alpha" => 255, "blue" => 129, "count" => 4915, "green" => 129, "hex" => "#7F8181", "red" => 127},
+      %{"alpha" => 255, "blue" => 150, "count" => 5913, "green" => 148, "hex" => "#939496", "red" => 147},
+      %{"alpha" => 255, "blue" => 191, "count" => 8142, "green" => 192, "hex" => "#BDC0BF", "red" => 189},
+      %{"alpha" => 255, "blue" => 244, "count" => 58242, "green" => 245, "hex" => "#F4F5F4", "red" => 244}
+    ]
     assert hist == expected
   end
 


### PR DESCRIPTION
Problem
--------

For some images with very narrow ranges, it appears ImageMagick can
return histograms that have fractional color entries.

Solution
--------

Make the histogram parser optionally look for integer or float color patterns.

