### PR TITLE
Implement and test lightweight "identify" function

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,15 @@ image = open("input.jpg") |> verbose
 IO.inspect(image) # => %Image{path: "input.jpg", ext: ".jpg", format: "jpeg", height: 292, width: 300}
 ```
 
+Getting reduced info in a "lighter" way (uses less memory):
+
+```elixir
+import Mogrify
+
+info = identify("input.jpg")
+IO.inspect(info) # => %{format: "jpeg", height: 292, width: 300}
+```
+
 Using custom commands to create an image with markup:
 
 ```elixir

--- a/README.md
+++ b/README.md
@@ -47,6 +47,15 @@ config :mogrify, convert_command: [
 ]
 ```
 
+Configure `identify` command:
+
+```elixir
+config :mogrify, identify_command: [
+  path: "identify",
+  args: []
+]
+```
+
 
 ## Examples
 

--- a/lib/mogrify.ex
+++ b/lib/mogrify.ex
@@ -121,8 +121,7 @@ defmodule Mogrify do
   defp clean_histogram_entry({"alpha", ""}), do: {"alpha", 255}
   defp clean_histogram_entry({k, ""}), do: {k, 0}
 
-  defp clean_histogram_entry({k, v}),
-    do: {k, v |> Float.parse() |> elem(0) |> Float.round(0) |> trunc}
+  defp clean_histogram_entry({k, v}), do: {k, v |> Float.parse() |> elem(0) |> Float.round(0) |> trunc}
 
   def extract_histogram_data(entry) do
     ~r/^\s+(?<count>\d+):\s+\((?<red>[\d(?:\.\d+)?)\s]+),(?<green>[\d(?:\.\d+)?)\s]+),(?<blue>[\d(?:\.\d+)?)\s]+)(,(?<alpha>[\d(?:\.\d+)?)\s]+))?\)\s+(?<hex>\#[abcdef\d]{6,8})\s+/i
@@ -226,8 +225,7 @@ defmodule Mogrify do
     image_information_string_to_map(output)
   end
 
-  @spec image_information_string_to_map(binary()) :: map()
-  def image_information_string_to_map(image_information_string) do
+  defp image_information_string_to_map(image_information_string) do
     ~r/\b(?<animated>\[0])? (?<format>\S+) (?<width>\d+)x(?<height>\d+)/
     |> Regex.named_captures(image_information_string)
     |> Enum.map(&normalize_verbose_term/1)
@@ -383,7 +381,9 @@ defmodule Mogrify do
 
       raise ArgumentError,
         message:
-          "the option #{option_name} need arguments. Be sure to pass arguments to option_#{prefix}#{option_name}(arg)"
+          "the option #{option_name} need arguments. Be sure to pass arguments to option_#{prefix}#{
+            option_name
+          }(arg)"
     end
   end
 
@@ -439,7 +439,6 @@ defmodule Mogrify do
     config = Application.get_env(:mogrify, :"#{command}_command", [])
     path = Keyword.get(config, :path)
     args = Keyword.get(config, :args, [])
-
     if path do
       {path, args}
     else

--- a/lib/mogrify.ex
+++ b/lib/mogrify.ex
@@ -120,7 +120,6 @@ defmodule Mogrify do
   defp clean_histogram_entry({"hex", v}), do: {"hex", v}
   defp clean_histogram_entry({"alpha", ""}), do: {"alpha", 255}
   defp clean_histogram_entry({k, ""}), do: {k, 0}
-
   defp clean_histogram_entry({k, v}), do: {k, v |> Float.parse() |> elem(0) |> Float.round(0) |> trunc}
 
   def extract_histogram_data(entry) do

--- a/test/mogrify_test.exs
+++ b/test/mogrify_test.exs
@@ -350,6 +350,10 @@ defmodule MogrifyTest do
     assert %Image{frame_count: 2} = open(@fixture_animated) |> verbose
   end
 
+  test ".identify" do
+    assert %{format: "jpeg", height: 292, width: 300, animated: false} = identify(@fixture)
+  end
+
   test ".format" do
     image = open(@fixture) |> format("png") |> save |> verbose
     assert %Image{ext: ".png", format: "png", height: 292, width: 300} = image


### PR DESCRIPTION
I wrote a simple function that uses imagemagick's "identify" function to get information about an image file.

I was motivated to do this when I tried using `verbose` to get information about a 1.1MB image on a "free tier" gigalixir app (which has severe memory limits) and hit an OOM problem. It seems strange to run out of memory just trying to get the width and height of an image so I ended up copying code out of this project (especially the regex for parsing the image information string, thanks for that!) and just writing my own function for getting image info.

When I tried my own function on the free tier gigalixir app, I stopped getting OOM issues, so i thought it would be good to make a PR for this.